### PR TITLE
Fix for gcc 10.0

### DIFF
--- a/source/lib/dng_sdk/dng_negative.cpp
+++ b/source/lib/dng_sdk/dng_negative.cpp
@@ -2881,7 +2881,7 @@ void dng_negative::SetFujiMosaic6x6 (uint32 phase)
 			
 			}
 
-		info = temp;
+		dng_mosaic_info &info = temp;
 		
 		}
 		


### PR DESCRIPTION
In member function 'dng_mosaic_info& dng_mosaic_info::operator=(const dng_mosaic_info&)',
    inlined from 'void dng_negative::SetFujiMosaic6x6(uint32)' at dng_negative.cpp:2884:10:
dng_mosaic_info.h:32:7: warning: writing 1 byte into a region of size 0 [-Wstringop-overflow=]
   32 | class dng_mosaic_info
      |       ^~~~~~~~~~~~~~~